### PR TITLE
Add support for change event propagation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The collection will create events much like a regular collection. There are a fe
  - `remove`: An object was removed from the collection (via filter OR via orig collection)
  - `reset`: The original collection was reset, filtering happened
  - `sort`: Same as reset, but via sort
+ - `change`: An object in the collection was changed.
  - `filter-complete`: Filtering was completed. If you are not listening to add/remove then just listen to filter-complete and reset your views.
 
 # Testing

--- a/spec/javascripts/backbone-filtered-collection-spec.js
+++ b/spec/javascripts/backbone-filtered-collection-spec.js
@@ -332,6 +332,32 @@ describe("Backbone.FilteredCollection", function() {
       expect(collection.models[0].get("value")).toEqual(1)
     });
 
+    it("should trigger change event if the model is altered", function () {
+      origModelZero = collection.models[0];
+      var triggered = false;
+
+      collection.on("change", function (model) {
+        triggered = true;
+      });
+
+      origModelZero.set("value", 10);
+
+      expect(triggered).toEqual(true)
+    });
+
+    it("should pass the changed model to the handler", function () {
+      origModelZero = collection.models[0];
+      var changedValue = null;
+
+      collection.on("change", function (model) {
+        changedValue = model.get('value');
+      });
+
+      origModelZero.set("value", 10);
+
+      expect(changedValue).toEqual(10);
+    });
+
     it("should do nothing if the model is still passing the filter", function() {
       collection.setFilter(createLessthanFilter(5));
       origModelZero = collection.models[0];

--- a/vendor/assets/javascripts/backbone-filtered-collection.js
+++ b/vendor/assets/javascripts/backbone-filtered-collection.js
@@ -94,6 +94,7 @@ THE SOFTWARE.
         }
       }
       if (! options.silent) {
+        this.trigger('change', model);
         this._filterComplete();
       }
     }


### PR DESCRIPTION
filter-complete is too low a granularity for changes which need to
only render a portion of a UI. As such, this change creates a change
event when a model in the underlying collection changes.
