### PR TITLE
Added method #resetWith to be able to reuse the same filtered collection with different collections.

### DIFF
--- a/spec/javascripts/backbone-filtered-collection-spec.js
+++ b/spec/javascripts/backbone-filtered-collection-spec.js
@@ -383,9 +383,12 @@ describe("Backbone.FilteredCollection", function() {
   describe("#resetWith", function() {
     var originalCollection,
       newCollection,
-      filteredCollection;
+      filteredCollection,
+      eventSpy;
 
     beforeEach(function(){
+      eventSpy = jasmine.createSpy('event listener');
+
       originalCollection = new Backbone.Collection([{
           id: 1, value: 1, deleted: false
         }, {
@@ -443,6 +446,31 @@ describe("Backbone.FilteredCollection", function() {
       }));
 
       expect(filteredCollection.length).toEqual(0);
+    });
+
+    it("should keep change event working", function() {
+      filteredCollection.resetWith(newCollection);
+
+      newCollection.get(3).set('deleted', true);
+
+      expect(filteredCollection.length).toEqual(0);
+    });
+
+    it("should ignore the old collection events", function() {
+      // Change the original with a new one
+      filteredCollection.resetWith(newCollection);
+
+      // Listen all the events on the filtered collection
+      filteredCollection.on('all', function() {
+        eventSpy('Ouch');
+      });
+
+      // Make changes to the original collection
+      originalCollection.add(new Backbone.Model({id: 4, deleted: false}));
+      originalCollection.remove(new Backbone.Model({id: 3}));
+      originalCollection.get(1).set('deleted', true);
+
+      expect(eventSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/spec/javascripts/backbone-filtered-collection-spec.js
+++ b/spec/javascripts/backbone-filtered-collection-spec.js
@@ -472,5 +472,27 @@ describe("Backbone.FilteredCollection", function() {
 
       expect(eventSpy).not.toHaveBeenCalled();
     });
+
+    it("should fire a reset with the new filtered data", function() {
+      var expectedFilteredCollection = new Backbone.FilteredCollection(null, {
+        collection: newCollection,
+        collectionFilter: function(item) {
+          return !item.get('deleted')
+        }
+      }),
+      filteredCollectionAfterCallResetWith = null;
+
+      filteredCollection.on('reset', function(collection) {
+        filteredCollectionAfterCallResetWith = collection;
+      });
+
+      filteredCollection.resetWith(newCollection);
+
+      expect(_.difference(
+        expectedFilteredCollection.pluck('id'),
+        filteredCollectionAfterCallResetWith.pluck('id')
+      )).toEqual([]);
+    });
+
   });
 });

--- a/spec/javascripts/backbone-filtered-collection-spec.js
+++ b/spec/javascripts/backbone-filtered-collection-spec.js
@@ -379,4 +379,70 @@ describe("Backbone.FilteredCollection", function() {
       expect(removeSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe("#resetWith", function() {
+    var originalCollection,
+      newCollection,
+      filteredCollection;
+
+    beforeEach(function(){
+      originalCollection = new Backbone.Collection([{
+          id: 1, value: 1, deleted: false
+        }, {
+          id: 2, value: 2, deleted: false
+        }, {
+          id: 3, value: 3, deleted: true
+        }]);
+
+      newCollection = new Backbone.Collection([{
+          id: 1, value: 1, deleted: true
+        }, {
+          id: 2, value: 2, deleted: true
+        }, {
+          id: 3, value: 3, deleted: false
+        }]);
+
+      filteredCollection = new Backbone.FilteredCollection(null, {
+        collection: originalCollection,
+        collectionFilter: function(item) {
+          return !item.get('deleted')
+        }
+      });
+    });
+
+    it("should reset the current instance with a new collection and update the length with the correct value", function() {
+      var l1 = filteredCollection.length;
+
+      filteredCollection.resetWith(newCollection);
+
+      var l2 = filteredCollection.length;
+
+      expect(l1).toEqual(2);
+      expect(l2).toEqual(1);
+    });
+
+    it("should keep the add working", function() {
+      filteredCollection.resetWith(newCollection);
+
+      var lengthBeforeAdd = filteredCollection.length;
+
+      newCollection.add(new Backbone.Model({
+        id: 4, value: 4, deleted: false
+      }));
+
+      var lengthAfterAdd = filteredCollection.length;
+
+      expect(lengthBeforeAdd + 1).toEqual(lengthAfterAdd);
+    });
+
+    it("should keep the remove working", function() {
+      filteredCollection.resetWith(newCollection);
+
+      newCollection.remove(new Backbone.Model({
+        id: 3
+      }));
+
+      expect(filteredCollection.length).toEqual(0);
+    });
+  });
 });

--- a/vendor/assets/javascripts/backbone-filtered-collection.js
+++ b/vendor/assets/javascripts/backbone-filtered-collection.js
@@ -81,30 +81,11 @@ THE SOFTWARE.
     @param {Backbone.Collection} newCollection - New collection to be wrapped
     @method
     @chainable
-
-    @example
-        var a = new Backbone.Collection(),
-          b = new Backbone.Collection(),
-          filtered = new Backbone.FilteredCollection({
-            collection: a
-          });
-
-        // do something with the filtered collection
-
-        filtered.resetWith(b);
-
-        // continue using the collection b instead of a as datasource
     **/
     ,resetWith: function(newCollection) {
-      // Stop listening the old collection
       this.stopListening();
-      // Reset the current state to "empty"
-      this._reset();
-      // Update the collection with the new one
       this.setCollection(newCollection);
-      // Fires the filtering
-      this.setFilter();
-      // Bind all the events on the new collection
+      this.resetCollection();
       this._bindEvents();
 
       return this;

--- a/vendor/assets/javascripts/backbone-filtered-collection.js
+++ b/vendor/assets/javascripts/backbone-filtered-collection.js
@@ -79,8 +79,21 @@ THE SOFTWARE.
     Replace the current collection with a new one reusing the same instance.
 
     @param {Backbone.Collection} newCollection - New collection to be wrapped
-
     @method
+    @chainable
+
+    @example
+        var a = new Backbone.Collection(),
+          b = new Backbone.Collection(),
+          filtered = new Backbone.FilteredCollection({
+            collection: a
+          });
+
+        // do something with the filtered collection
+
+        filtered.resetWith(b);
+
+        // continue using the collection b instead of a as datasource
     **/
     ,resetWith: function(newCollection) {
       // Stop listening the old collection
@@ -93,6 +106,8 @@ THE SOFTWARE.
       this.setFilter();
       // Bind all the events on the new collection
       this._bindEvents();
+
+      return this;
     }
 
     /**

--- a/vendor/assets/javascripts/backbone-filtered-collection.js
+++ b/vendor/assets/javascripts/backbone-filtered-collection.js
@@ -46,17 +46,69 @@ THE SOFTWARE.
     collectionFilter: null
     ,defaultFilter: defaultFilter
 
+    /**
+    Default initializer.
+
+    @param {Boolean} [models=false] - By default we must to use a falsy value here.
+    @param {Object}  data           - Options.
+        @param {Backbone.Collection} data.collection       - Collection to be filtered
+        @param {Function}            data.collectionFilter - Filter to be applied to the collection.
+
+    @constructor
+    **/
     ,initialize: function(models, data) {
       if (models) throw "models cannot be set directly, unfortunately first argument is the models.";
-      this.collection = data.collection;
-      this.setFilter(data.collectionFilter);
 
-      this.collection.on("add",             this.addModel, this);
-      this.collection.on("remove",          this.removeModel, this);
-      this.collection.on("reset",           this.resetCollection, this);
-      this.collection.on("sort",            this.resortCollection, this);
-      this.collection.on("change",          this._modelChanged, this);
-      this.collection.on("filter-complete", this._filterComplete, this);
+      this.setCollection(data.collection);
+      this.setFilter(data.collectionFilter);
+      this._bindEvents();
+    }
+
+    /**
+    Collection setter.
+
+    @param {Backbone.Collection} c - Collection to be wrapped
+
+    @method
+    **/
+    ,setCollection: function(c) {
+      this.collection = c;
+    }
+
+    /**
+    Replace the current collection with a new one reusing the same instance.
+
+    @param {Backbone.Collection} newCollection - New collection to be wrapped
+
+    @method
+    **/
+    ,resetWith: function(newCollection) {
+      // Stop listening the old collection
+      this.stopListening();
+      // Reset the current state to "empty"
+      this._reset();
+      // Update the collection with the new one
+      this.setCollection(newCollection);
+      // Fires the filtering
+      this.setFilter();
+      // Bind all the events on the new collection
+      this._bindEvents();
+    }
+
+    /**
+    Register listeners to the current collection.
+
+    @see Backbone.Event.stopListening
+
+    @method
+    **/
+    ,_bindEvents: function () {
+      this.listenTo(this.collection, "add", this.addModel);
+      this.listenTo(this.collection, "remove", this.removeModel);
+      this.listenTo(this.collection, "reset", this.resetCollection);
+      this.listenTo(this.collection, "sort", this.resortCollection);
+      this.listenTo(this.collection, "change", this._modelChanged);
+      this.listenTo(this.collection, "filter-complete", this._filterComplete);
     }
 
     ,_reset: function(options) {


### PR DESCRIPTION
The main idea behind this PR:
1. Be able to change the base collection without create a new instance of the filtered collection. 
2. I have updated the event listeners to use `.listenTo` instead `.on` because Backbone provides a better way to unbind all the events at once using the method `.stopListening`.

Please let me know if anything needs to be changed/updated in order to make this PR mergeable :smile: 

Thanks!
